### PR TITLE
feat: implemented unique result URL for a each specimen upload

### DIFF
--- a/port_inspector/port_inspector/urls.py
+++ b/port_inspector/port_inspector/urls.py
@@ -41,6 +41,6 @@ urlpatterns = [
         views.verify_email_complete,
         name="verify-email-complete",
     ),
-    path("results/", views.results_view, name="results"),
+    path("results/<str:hashed_ID>", views.results_view, name="results"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # storing uploaded images to our MEDIA_URL

--- a/port_inspector/port_inspector_app/test.py
+++ b/port_inspector/port_inspector_app/test.py
@@ -186,7 +186,6 @@ class ResultsViewTests(TestCase):
         hashed_ID = "mocked_hash_value"  # Fake hash
         response = results_view(request, hashed_ID)
 
-
         # Check that the response status code is 200
         self.assertEqual(response.status_code, 200)
 
@@ -212,7 +211,6 @@ class ResultsViewTests(TestCase):
         # Call the view function
         hashed_ID = "mocked_hash_value"  # Fake hash
         response = results_view(request, hashed_ID)
-
 
         # Check that the response status code is 200
         self.assertEqual(response.status_code, 200)

--- a/port_inspector/port_inspector_app/test.py
+++ b/port_inspector/port_inspector_app/test.py
@@ -2,10 +2,10 @@ from django.test import TestCase
 from unittest.mock import patch, MagicMock
 from django.urls import reverse
 from django.http import HttpRequest
-from django.core.mail import outbox
 from django.core.exceptions import ValidationError
 from port_inspector_app.views import results_view
 from port_inspector_app.models import SpecimenUpload, Genus, KnownSpecies, User, Image
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 
 class UserEmailIntegrationTests(TestCase):
@@ -183,7 +183,8 @@ class ResultsViewTests(TestCase):
         request.method = 'GET'
 
         # Call the view function
-        response = results_view(request)
+        hashed_ID = "mocked_hash_value"  # Fake hash
+        response = results_view(request, hashed_ID)
 
         # Check that the response status code is 200
         self.assertEqual(response.status_code, 200)
@@ -208,7 +209,8 @@ class ResultsViewTests(TestCase):
         request.method = 'GET'
 
         # Call the view function
-        response = results_view(request)
+        hashed_ID = "mocked_hash_value"  # Fake hash
+        response = results_view(request, hashed_ID)
 
         # Check that the response status code is 200
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** In this PR, I changed our upload view so that once a person uploads photos, they are redirected to a unique results url page that uses the specimen pk with a hash to make it unique

## UI/UX Implementation

No changes Made

## Model Updates

No changes made

### Data Models

no changes made

### Object-Oriented Models

No changes made

## End-to-End Testing Instructions

run docker compose up

go to http://0.0.0.0:8000/uploads/

upload 1-4 photos, hit the upload button

be redirected to a page called http://0.0.0.0:8000/results/<unique_hash_value>
