### PR TITLE
feat: made it so that on the history page, the id links to the result…

### DIFF
--- a/port_inspector/port_inspector_app/templates/history.html
+++ b/port_inspector/port_inspector_app/templates/history.html
@@ -152,12 +152,12 @@
             <tbody>
                 {% for upload in uploads %}
                 <tr>
-                    <td>{{ upload.id }}</td>
+                    <td><a href="{% url 'results' upload.1 %}" target="_blank">{{ upload.0.id }}</a></td>
                     <td>{{ upload.upload_date.date|default:"No date" }}</td>
                     <td>{{ upload.upload_date.time|default:"No time" }}</td>
                     <td>
                         {% if upload.frontal_image and upload.frontal_image.image %}
-                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.frontal_image.image }}')">Frontal</a>
+                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.0.frontal_image.image }}')">Frontal</a>
                         {% else %}
                             No image
                         {% endif %}
@@ -165,7 +165,7 @@
                 
                     <td>
                         {% if upload.dorsal_image and upload.dorsal_image.image %}
-                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.dorsal_image.image }}')">Dorsal</a>
+                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.0.dorsal_image.image }}')">Dorsal</a>
                         {% else %}
                             No image
                         {% endif %}
@@ -173,7 +173,7 @@
                 
                     <td>
                         {% if upload.caudal_image and upload.caudal_image.image %}
-                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.caudal_image.image }}')">Caudal</a>
+                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.0.caudal_image.image }}')">Caudal</a>
                         {% else %}
                             No image
                         {% endif %}
@@ -181,7 +181,7 @@
                 
                     <td>
                         {% if upload.lateral_image and upload.lateral_image.image %}
-                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.lateral_image.image }}')">Lateral</a>
+                            <a class="view-link" onclick="openModal('{{ MEDIA_URL }}{{ upload.0.lateral_image.image }}')">Lateral</a>
                         {% else %}
                             No image
                         {% endif %}

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -18,6 +18,7 @@ from .tokens import account_activation_token
 
 SALT_KEY = "callosobruchus!maculatus"
 
+
 def verify_email(request):
     if request.method == "POST":
         if not request.user.is_email_verified:

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -16,6 +16,7 @@ from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from .tokens import account_activation_token
 
+SALT_KEY = "callosobruchus!maculatus"
 
 def verify_email(request):
     if request.method == "POST":
@@ -117,7 +118,6 @@ def logout_view(request):
 
 
 def upload_image(request):
-    SALT_KEY = "callosobruchus!maculatus"
     if request.method == "POST":
         specimen_form = SpecimenUploadForm(request.POST, request.FILES)
 
@@ -138,7 +138,11 @@ def upload_image(request):
 def view_history(request):
     if request.user.is_authenticated:
         # create empty set of type SpecimenUpload
-        uploads = SpecimenUpload.objects.filter(user=request.user)
+        specimen = SpecimenUpload.objects.filter(user=request.user)
+        uploads = []
+        for upload in specimen:
+            hashed_ID = hmac.new(SALT_KEY.encode(), f"{upload.id}".encode(), hashlib.sha256).hexdigest()
+            uploads.append((upload, hashed_ID))
         return render(request, 'history.html', {'uploads': uploads, 'MEDIA_URL': settings.MEDIA_URL})
     else:
         return redirect("/login/")


### PR DESCRIPTION
…s page of the upload

# Overview

**Type of Change:** New Feature

**Summary:** In the history table, when you click on the ID of an upload, it will be hyperlinked and take you to the results page for that upload

## UI/UX Implementation

id numbers are now in blue and underlined


## End-to-End Testing Instructions

start up the web app, go to the history page, click on any id number and be redirected to the results page.

**NOTE: we may consider adding the hashedID as a variable of the Specimen Upload database to reduce time spent hashing (next sprint)
