### PR TITLE
Unkown button functionality

### DIFF
--- a/port_inspector/port_inspector/urls.py
+++ b/port_inspector/port_inspector/urls.py
@@ -42,5 +42,6 @@ urlpatterns = [
         name="verify-email-complete",
     ),
     path("results/<str:hashed_ID>", views.results_view, name="results"),
+	 path("notify_unknown/", views.notify_unknown, name="notify_unknown"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # storing uploaded images to our MEDIA_URL

--- a/port_inspector/port_inspector/urls.py
+++ b/port_inspector/port_inspector/urls.py
@@ -41,7 +41,6 @@ urlpatterns = [
         views.verify_email_complete,
         name="verify-email-complete",
     ),
-    path("results/<str:hashed_ID>", views.results_view, name="results"),
-	 path("notify_unknown/", views.notify_unknown, name="notify_unknown"),
+    path("results/<str:hashed_ID>", views.results_view, name="results"), path("notify_unknown/", views.notify_unknown, name="notify_unknown"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # storing uploaded images to our MEDIA_URL

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -232,3 +232,15 @@ def results_view(request, hashed_ID):
             "confirm_form": confirm_form
         },
     )
+
+def notify_unknown(request):
+    if request.method == "POST":
+        user = request.user
+        send_to_email = "akrishnadasan@sandiego.edu" #this will be dr.Morse's email
+        subject = "Port Inspector App - Unknown Species Uploaded"
+        message = "help, an unkown species what uploaded" #want to put results page of upload
+        email = EmailMessage(subject, message, to=[send_to_email])
+        email.content_subtype = "html"
+        email.send()
+
+    return redirect("/history/")

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -233,10 +233,12 @@ def results_view(request, hashed_ID):
         },
     )
 
+
 def notify_unknown(request):
     if request.method == "POST":
-        user = request.user
-        send_to_email = "akrishnadasan@sandiego.edu" #this will be dr.Morse's email
+        #  user = request.user
+        send_to_email = "akrishnadasan@sandiego.edu"
+        #  this will be dr.Morse's email
         results_page_url = request.META.get("HTTP_REFERER", "/history/")
         subject = "Port Inspector App - Unknown Species Uploaded"
         message = f"""

--- a/port_inspector/port_inspector_app/views.py
+++ b/port_inspector/port_inspector_app/views.py
@@ -237,8 +237,15 @@ def notify_unknown(request):
     if request.method == "POST":
         user = request.user
         send_to_email = "akrishnadasan@sandiego.edu" #this will be dr.Morse's email
+        results_page_url = request.META.get("HTTP_REFERER", "/history/")
         subject = "Port Inspector App - Unknown Species Uploaded"
-        message = "help, an unkown species what uploaded" #want to put results page of upload
+        message = f"""
+        <p>Hello,</p>
+        <p>A user was unable to identify a specimen.</p>
+        <p>Confirm the identification here: <a href="{results_page_url}">{results_page_url}</a></p>
+        <p>Best,</p>
+        <p>Port Inspector App Team</p>
+        """
         email = EmailMessage(subject, message, to=[send_to_email])
         email.content_subtype = "html"
         email.send()


### PR DESCRIPTION
# Overview

**Type of Change:**  New Feature

**Summary:**  This PR implements the functionality of the "unknown" button on the results page - it sends an email to a specified admin user (right now it is sent to my email) in order to notify them of an unknown species. This allows for further identification by Dr. Morse for these species


## End-to-End Testing Instructions

Log in, upload a photo(s). Once you are on the results page, click "unknown" and you will be directed back to the upload history page. I will be sent an email!
