### PR TITLE
DigitalOcean Email Fixes

### DIFF
--- a/port_inspector/beetle_detection/species_eval.py
+++ b/port_inspector/beetle_detection/species_eval.py
@@ -1,56 +1,58 @@
 # flake8: noqa
-""" simulator.py """
-import json, os
-from PIL import Image
-from .model_loader import ModelLoader
-from .evaluation_method import EvaluationMethod
-from .genus_evaluation_method import GenusEvaluationMethod
-from django.conf import settings
-
-# -----Run once on import-----
-# read json to see size of outputs
-# with open("./port_inspector/beetle_detection/spec_dict.json", 'r', encoding='utf-8') as spec_dict:
-    # SPECIES_OUTPUTS = len(json.load(spec_dict))
-    # TODO this should be from the json file but for now we hard code to 15 because of the weights given from ML team
-# with open("./port_inspector/beetle_detection/gen_dict.json", 'r', encoding='utf-8') as gen_dict:
-    # GENUS_OUTPUTS = len(json.load(gen_dict))
-    # TODO same here, should be read from json file
-
-SPECIES_OUTPUTS = 15
-GENUS_OUTPUTS = 9
-
-# Load species models
-species_model_paths = {
-        "caud" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_caud.pth"), 
-        "dors" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_dors.pth"),
-        "fron" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_fron.pth"),
-        "late" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_late.pth")
-    }
-species_ml = ModelLoader(species_model_paths, SPECIES_OUTPUTS)
-species_models = species_ml.get_models()
-# Set models to evaluation mode
-for key in species_models:
-    species_models[key].eval()
-
-# Load genus models
-genus_model_paths = {
-        "caud" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_caud.pth"), 
-        "dors" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_dors.pth"),
-        "fron" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_fron.pth"),
-        "late" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_late.pth")
-    }
-genus_ml = ModelLoader(genus_model_paths, GENUS_OUTPUTS)
-genus_models = genus_ml.get_models()
-# Set genus models to evaluation mode
-for key in genus_models:
-    genus_models[key].eval()
+import json, os, sys
 
 
-# Initialize the EvaluationMethod object with the heaviest eval method set
-species_evaluator = EvaluationMethod(os.path.join(os.path.dirname(os.path.abspath(__file__)), "height.txt"), species_models, 1, os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_dict.json"))
-genus_evaluator = GenusEvaluationMethod(os.path.join(os.path.dirname(os.path.abspath(__file__)), "height.txt"), genus_models, 1, os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_dict.json"))
+# -----Run once on server start up-----
+if "runserver" in sys.argv:
+    from PIL import Image
+    from .model_loader import ModelLoader
+    from .evaluation_method import EvaluationMethod
+    from .genus_evaluation_method import GenusEvaluationMethod
+    from django.conf import settings
 
-print("!!! ML Models loaded in evaluation mode !!!")
+    # read json to see size of outputs
+    # with open("./port_inspector/beetle_detection/spec_dict.json", 'r', encoding='utf-8') as spec_dict:
+        # SPECIES_OUTPUTS = len(json.load(spec_dict))
+        # TODO this should be from the json file but for now we hard code to 15 because of the weights given from ML team
+    # with open("./port_inspector/beetle_detection/gen_dict.json", 'r', encoding='utf-8') as gen_dict:
+        # GENUS_OUTPUTS = len(json.load(gen_dict))
+        # TODO same here, should be read from json file
+
+    SPECIES_OUTPUTS = 15
+    GENUS_OUTPUTS = 9
+
+    # Load species models
+    species_model_paths = {
+            "caud" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_caud.pth"), 
+            "dors" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_dors.pth"),
+            "fron" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_fron.pth"),
+            "late" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_late.pth")
+        }
+    species_ml = ModelLoader(species_model_paths, SPECIES_OUTPUTS)
+    species_models = species_ml.get_models()
+    # Set models to evaluation mode
+    for key in species_models:
+        species_models[key].eval()
+
+    # Load genus models
+    genus_model_paths = {
+            "caud" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_caud.pth"), 
+            "dors" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_dors.pth"),
+            "fron" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_fron.pth"),
+            "late" : os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_late.pth")
+        }
+    genus_ml = ModelLoader(genus_model_paths, GENUS_OUTPUTS)
+    genus_models = genus_ml.get_models()
+    # Set genus models to evaluation mode
+    for key in genus_models:
+        genus_models[key].eval()
+
+
+    # Initialize the EvaluationMethod object with the heaviest eval method set
+    species_evaluator = EvaluationMethod(os.path.join(os.path.dirname(os.path.abspath(__file__)), "height.txt"), species_models, 1, os.path.join(os.path.dirname(os.path.abspath(__file__)), "spec_dict.json"))
+    genus_evaluator = GenusEvaluationMethod(os.path.join(os.path.dirname(os.path.abspath(__file__)), "height.txt"), genus_models, 1, os.path.join(os.path.dirname(os.path.abspath(__file__)), "gen_dict.json"))
+
+    print("!!! ML Models loaded in evaluation mode !!!")
 
 
 def evaluate_images(late_path, dors_path, fron_path, caud_path):

--- a/port_inspector/port_inspector/settings.py
+++ b/port_inspector/port_inspector/settings.py
@@ -147,8 +147,8 @@ DEFAULT_FROM_EMAIL = 'usdportinspector@test-68zxl2773n94j905.mlsender.net'
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.mailersend.net'
 EMAIL_PORT = 2525
-EMAIL_HOST_USER = 'MS_QdPaSd@test-68zxl2773n94j905.mlsender.net'
-EMAIL_HOST_PASSWORD = 'mssp.Sg9272B.pxkjn41pv5p4z781.vtj1F7n'
+EMAIL_HOST_USER = 'MS_y94oDQ@port-inspector-app.dedyn.io'
+EMAIL_HOST_PASSWORD = 'mssp.mUZgWhh.yzkq340ovkk4d796.qhMGgHo'
 EMAIL_USE_TLS = True
 
 SALT_KEY = "callosobruchus!maculatus"

--- a/port_inspector/port_inspector/settings.py
+++ b/port_inspector/port_inspector/settings.py
@@ -147,8 +147,9 @@ DEFAULT_FROM_EMAIL = 'usdportinspector@test-68zxl2773n94j905.mlsender.net'
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.mailersend.net'
 EMAIL_PORT = 2525
-EMAIL_HOST_USER = 'MS_y94oDQ@port-inspector-app.dedyn.io'
-EMAIL_HOST_PASSWORD = 'mssp.mUZgWhh.yzkq340ovkk4d796.qhMGgHo'
+EMAIL_HOST_USER = 'MS_Hd5uH9@port-inspector-app.dedyn.io'
+# Add password in production
+EMAIL_HOST_PASSWORD = '[password_here]'
 EMAIL_USE_TLS = True
 
 SALT_KEY = "callosobruchus!maculatus"

--- a/port_inspector/port_inspector/settings.py
+++ b/port_inspector/port_inspector/settings.py
@@ -142,14 +142,15 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = 'port_inspector_app.User'
 
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+DEFAULT_FROM_EMAIL = 'usdportinspector@test-68zxl2773n94j905.mlsender.net'
 
-EMAIL_HOST = "smtp.gmail.com"
-EMAIL_HOST_USER = "usdportinspector@gmail.com"
-EMAIL_HOST_PASSWORD = "ogxo gxzh acjz hrwu"
-EMAIL_PORT = 587
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.mailersend.net'
+EMAIL_PORT = 2525
+EMAIL_HOST_USER = 'MS_QdPaSd@test-68zxl2773n94j905.mlsender.net'
+EMAIL_HOST_PASSWORD = 'mssp.Sg9272B.pxkjn41pv5p4z781.vtj1F7n'
 EMAIL_USE_TLS = True
-DEFAULT_FROM_EMAIL = "BeetleID usdportinspector@gmail.com"
+
 SALT_KEY = "callosobruchus!maculatus"
 
 USER_MAX_UPLOADS = 50


### PR DESCRIPTION
# Overview

**Type of Change:** Refactor

**Summary:** 
Set up a MailerSend account with our project Gmail, and modified DNS entries to send SMTP data over port 2525 to mailersend which will handle sending our verify account emails.

## UI/UX Implementation
N/A

## Model Updates
N/A

## End-to-End Testing Instructions
Attempted our sign up workflow, to ensure emails are properly sent with the new setup, which should no longer be blocked by DigitalOcean since it will be over port 2525.